### PR TITLE
Fixed use of deprecated APIs in io.jsonwebtoken signWith and setSigningKey

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ repositories {
 ext {
   set('springCloudVersion', "Hoxton.SR4")
   set('mapstructVersion', "1.3.1.Final")
-  set('jwtVersion', "0.11.1")
+  set('jwtVersion', "0.11.2")
   set('bouncycastleVersion', "1.65")
   set('openApiVersion', "1.4.1")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ repositories {
 ext {
   set('springCloudVersion', "Hoxton.SR4")
   set('mapstructVersion', "1.3.1.Final")
-  set('jwtVersion', "0.11.2")
+  set('jwtVersion', "0.11.1")
   set('bouncycastleVersion', "1.65")
   set('openApiVersion', "1.4.1")
 }

--- a/src/main/java/com/myhome/security/MyHomeAuthenticationFilter.java
+++ b/src/main/java/com/myhome/security/MyHomeAuthenticationFilter.java
@@ -21,8 +21,6 @@ import com.myhome.controllers.dto.UserDto;
 import com.myhome.controllers.request.LoginUserRequest;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.SigningKeyResolverAdapter;
-import io.jsonwebtoken.JwsHeader;
 import io.jsonwebtoken.security.Keys;
 import java.io.IOException;
 import java.util.Collections;
@@ -39,7 +37,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import java.security.Key;
 
 
 /**

--- a/src/main/java/com/myhome/security/MyHomeAuthenticationFilter.java
+++ b/src/main/java/com/myhome/security/MyHomeAuthenticationFilter.java
@@ -21,6 +21,9 @@ import com.myhome.controllers.dto.UserDto;
 import com.myhome.controllers.request.LoginUserRequest;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.SigningKeyResolverAdapter;
+import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.security.Keys;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Date;
@@ -36,6 +39,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import java.security.Key;
+
 
 /**
  * Custom {@link UsernamePasswordAuthenticationFilter} for catering to service need. Generates JWT
@@ -80,7 +85,8 @@ public class MyHomeAuthenticationFilter extends UsernamePasswordAuthenticationFi
         .setSubject(userDto.getUserId())
         .setExpiration(new Date(System.currentTimeMillis() + Long.parseLong(
             Objects.requireNonNull(environment.getProperty("token.expiration_time")))))
-        .signWith(SignatureAlgorithm.HS512, environment.getProperty("token.secret"))
+        .signWith(Keys.hmacShaKeyFor(environment.getProperty("token.secret").getBytes()),
+                SignatureAlgorithm.HS512) //to replace the deprecated API calls, you need to call the signWith(Key, SignatureAlgorithm) method. For this you need to convert the string token to a Key (SecretKey in this case) and this can be done as here
         .compact();
 
     response.addHeader("token", token);

--- a/src/main/java/com/myhome/security/MyHomeAuthorizationFilter.java
+++ b/src/main/java/com/myhome/security/MyHomeAuthorizationFilter.java
@@ -23,6 +23,8 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import io.jsonwebtoken.security.Keys;
 import org.springframework.core.env.Environment;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -66,12 +68,12 @@ public class MyHomeAuthorizationFilter extends BasicAuthenticationFilter {
 
     String token =
         authHeader.replace(environment.getProperty("authorization.token.header.prefix"), "");
-    String userId = Jwts.parser()
-        .setSigningKey(environment.getProperty("token.secret"))
+    String userId = Jwts.parserBuilder()
+        .setSigningKey(Keys.hmacShaKeyFor(environment.getProperty("token.secret").getBytes())) //key needed to be changed here to match the one used in MyHomeAuthenticationFilter.successfulAuthentication
+            .build() //the build function is now required to replace deprecated API
         .parseClaimsJws(token)
         .getBody()
         .getSubject();
-
     if (userId == null) {
       return null;
     }


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
I replaced calls to deprecated API functions as of issue #59 
To do this, in com.myhome.security.MyHomeAuthenticationFilter I had to change the signWith method to use the method signWith(Key, SignatureAlgorithm). This required converting the String token.secret to a hmac sha secret key first.

I also had to replace com.myhome.security.MyHomeAuthorizationFilter the parser in the getAuthentication method as the call to Jwts.parser() is being deprecated(I noticed it will be when I was reading through the io.jsonwebtoken GitHub), which has not been changed in the last pull request, so I thought it would be useful (reject it if it is not required). This had to be replaced with Jwts.parserBuilder() and set the signing key with the hmac sha key as above and then use .build()

I apologise if this is a step too far forward, but I thought I would change it as I read it in the docs

## 📄 Motivation and Context

Fixes issue #59

## 🧪 How Has This Been Tested?

I used Postman to test Creating a user, Logging in with that user, using the generated Bearer token from the login header and used it to List all users, Check status from auth and all ran successfully with the changes in MyHomeAuthenticationFilter and MyHomeAuthorizationFilter

## 📦 Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project(Do your best to follow code styles. If none apply just skip this).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
