### PR TITLE
Issue #149 : Add current user as Admin when creating a community

### DIFF
--- a/service/src/test/java/com/myhome/services/unit/CommunitySDJpaServiceTest.java
+++ b/service/src/test/java/com/myhome/services/unit/CommunitySDJpaServiceTest.java
@@ -41,6 +41,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -116,9 +118,14 @@ public class CommunitySDJpaServiceTest {
     // given
     CommunityDto testCommunityDto = getTestCommunityDto();
     Community testCommunity = getTestCommunity();
+    UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(TEST_ADMIN_ID,
+            null, Collections.emptyList());
+    SecurityContextHolder.getContext().setAuthentication(authentication);
 
     given(communityMapper.communityDtoToCommunity(testCommunityDto))
         .willReturn(testCommunity);
+    given(communityAdminRepository.findByUserIdWithCommunities(TEST_ADMIN_ID))
+            .willReturn(Optional.of(getTestAdmin()));
     given(communityRepository.save(testCommunity))
         .willReturn(testCommunity);
 
@@ -130,6 +137,7 @@ public class CommunitySDJpaServiceTest {
     assertEquals(testCommunityDto.getName(), createdCommunity.getName());
     assertEquals(testCommunityDto.getDistrict(), createdCommunity.getDistrict());
     verify(communityMapper).communityDtoToCommunity(testCommunityDto);
+    verify(communityAdminRepository).findByUserIdWithCommunities(TEST_ADMIN_ID);
     verify(communityRepository).save(testCommunity);
   }
 


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description

Adding the current user as Admin when creating a community. The userId is taken from the SecurityContextHolder.

## 📄 Motivation and Context

Change is required as there are no admins being assigned to a newly created community.
Fixes [Issue #149 ](https://github.com/jmprathab/MyHome/issues/149)

## 🧪 How Has This Been Tested?

Tested using Postman and Testcases.

## 📷 Screenshots (if appropriate)
NA

## 📦 Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project(Do your best to follow code styles. If none apply just skip this).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
