### PR TITLE
Issue #159: Endpoint to get all members of all houses a user is in

### DIFF
--- a/api/src/main/resources/api.yaml
+++ b/api/src/main/resources/api.yaml
@@ -85,6 +85,34 @@ paths:
                 $ref: '#/components/schemas/GetUserDetailsResponseUser'
         '404':
           description: "If userId is invalid"
+  /users/{userId}/housemates:
+    get:
+      tags:
+        - Users
+      description: "Lists all members from all houses of a user"
+      operationId: listAllHousemates
+      parameters:
+        - in: path
+          name: userId
+          schema:
+            type: string
+          required: true
+          description: ID of the user for which to find housemates
+        - in: query
+          name: pageable
+          required: false
+          schema:
+            $ref: '#/components/schemas/Pageable'
+      responses:
+        '200':
+          description: "Returns list of all members from all houses of the specified user"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListHouseMembersResponse'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ListHouseMembersResponse'
   /members/{memberId}/documents:
     get:
       tags:

--- a/service/src/main/java/com/myhome/repositories/HouseMemberRepository.java
+++ b/service/src/main/java/com/myhome/repositories/HouseMemberRepository.java
@@ -26,4 +26,7 @@ public interface HouseMemberRepository extends CrudRepository<HouseMember, Long>
   Optional<HouseMember> findByMemberId(String memberId);
 
   List<HouseMember> findAllByCommunityHouse_HouseId(String houseId, Pageable pageable);
+
+  List<HouseMember> findAllByCommunityHouse_Community_Admins_UserId(String userId,
+      Pageable pageable);
 }

--- a/service/src/main/java/com/myhome/services/HouseService.java
+++ b/service/src/main/java/com/myhome/services/HouseService.java
@@ -35,4 +35,6 @@ public interface HouseService {
   Optional<CommunityHouse> getHouseDetailsById(String houseId);
 
   Optional<List<HouseMember>> getHouseMembersById(String houseId, Pageable pageable);
+
+  Optional<List<HouseMember>> listHouseMembersForHousesOfUserId(String userId, Pageable pageable);
 }

--- a/service/src/main/java/com/myhome/services/springdatajpa/HouseSDJpaService.java
+++ b/service/src/main/java/com/myhome/services/springdatajpa/HouseSDJpaService.java
@@ -107,4 +107,12 @@ public class HouseSDJpaService implements HouseService {
         houseMemberRepository.findAllByCommunityHouse_HouseId(houseId, pageable)
     );
   }
+
+  @Override
+  public Optional<List<HouseMember>> listHouseMembersForHousesOfUserId(String userId,
+      Pageable pageable) {
+    return Optional.ofNullable(
+        houseMemberRepository.findAllByCommunityHouse_Community_Admins_UserId(userId, pageable)
+    );
+  }
 }

--- a/service/src/test/java/com/myhome/controllers/UserControllerTest.java
+++ b/service/src/test/java/com/myhome/controllers/UserControllerTest.java
@@ -17,15 +17,20 @@
 package com.myhome.controllers;
 
 import com.myhome.controllers.dto.UserDto;
+import com.myhome.controllers.dto.mapper.HouseMemberMapper;
 import com.myhome.controllers.mapper.UserApiMapper;
+import com.myhome.domain.HouseMember;
 import com.myhome.domain.User;
 import com.myhome.model.CreateUserRequest;
 import com.myhome.model.CreateUserResponse;
 import com.myhome.model.GetUserDetailsResponse;
 import com.myhome.model.GetUserDetailsResponseUser;
+import com.myhome.model.ListHouseMembersResponse;
+import com.myhome.services.HouseService;
 import com.myhome.services.UserService;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,6 +45,7 @@ import org.springframework.http.ResponseEntity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -55,6 +61,12 @@ class UserControllerTest {
 
   @Mock
   private UserApiMapper userApiMapper;
+
+  @Mock
+  private HouseService houseService;
+
+  @Mock
+  private HouseMemberMapper houseMemberMapper;
 
   @InjectMocks
   private UserController userController;
@@ -179,5 +191,70 @@ class UserControllerTest {
     assertEquals(expectedResponse, response.getBody());
     verify(userService).getUserDetails(userId);
     verify(userApiMapper).userDtoToGetUserDetailsResponse(userDto);
+  }
+
+  @Test
+  void shouldListAllHousematesSuccessWithNoResults() {
+    // given
+    String userId = TEST_ID;
+    int start = 50;
+    int limit = 150;
+    PageRequest pageRequest = PageRequest.of(start, limit);
+
+    given(houseService.listHouseMembersForHousesOfUserId(userId, pageRequest))
+        .willReturn(Optional.empty());
+
+    // when
+    ResponseEntity<ListHouseMembersResponse> response =
+        userController.listAllHousemates(userId, pageRequest);
+
+    // then
+    assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    assertNull(response.getBody());
+    then(houseService).should().listHouseMembersForHousesOfUserId(userId, pageRequest);
+    then(houseMemberMapper).shouldHaveNoInteractions();
+    then(userService).shouldHaveNoInteractions();
+    then(userApiMapper).shouldHaveNoInteractions();
+  }
+
+  @Test
+  void shouldListAllHousematesSuccessWithResults() {
+    // given
+    String userId = TEST_ID;
+    int start = 50;
+    int limit = 150;
+    PageRequest pageRequest = PageRequest.of(start, limit);
+
+    List<HouseMember> houseMemberList = Collections.singletonList(
+        new HouseMember(TEST_ID, null, TEST_NAME, null)
+    );
+
+    Set<com.myhome.model.HouseMember> responseSet = Collections.singleton(
+        new com.myhome.model.HouseMember()
+            .memberId(TEST_ID)
+            .name(TEST_NAME)
+    );
+
+    ListHouseMembersResponse expectedResponse = new ListHouseMembersResponse();
+    expectedResponse.setMembers(responseSet);
+
+    given(houseService.listHouseMembersForHousesOfUserId(userId, pageRequest))
+        .willReturn(Optional.of(houseMemberList));
+    given(houseMemberMapper.houseMemberSetToRestApiResponseHouseMemberSet(
+        new HashSet<>(houseMemberList)))
+        .willReturn(responseSet);
+
+    // when
+    ResponseEntity<ListHouseMembersResponse> response =
+        userController.listAllHousemates(userId, pageRequest);
+
+    // then
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(expectedResponse, response.getBody());
+    then(houseService).should().listHouseMembersForHousesOfUserId(userId, pageRequest);
+    then(houseMemberMapper).should()
+        .houseMemberSetToRestApiResponseHouseMemberSet(new HashSet<>(houseMemberList));
+    then(userService).shouldHaveNoInteractions();
+    then(userApiMapper).shouldHaveNoInteractions();
   }
 }


### PR DESCRIPTION
## 🚀 Description

This adds the requested endpoint for GET /users/{userId}/housemates.

Note: it doesn't appear that there is any link between Users and HouseMembers, so I'm not sure that the naming of this as "housemates" makes sense; however, it is implemented as requested in the issue.

## 📄 Motivation and Context

This resolves #159 

## 🧪 How Has This Been Tested?

I added a unit test for the controller, and manually ran a request for housemates of a user with `userId` of "default-user-id-for-testing", which resulted in a populated result.

## 📦 Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

- [x] My code follows the code style of this project(Do your best to follow code styles. If none apply just skip this).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
