### PR TITLE
Issue #114: Get all bookings for an amenity with an optional time range

### DIFF
--- a/postman/MyHome.postman_collection.json
+++ b/postman/MyHome.postman_collection.json
@@ -754,6 +754,45 @@
 			"response": []
 		},
 		{
+			"name": "List amenity bookings",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{AUTH_TOKEN}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "http://{{ENV_URL}}/amenities/{{AMENITY_ID}}/bookings?start='10-10-2020'",
+					"protocol": "http",
+					"host": [
+						"{{ENV_URL}}"
+					],
+					"path": [
+						"amenities",
+						"{{AMENITY_ID}}",
+						"bookings"
+					],
+					"query": [
+						{
+							"key": "end",
+							"value": "'10-25-2020'",
+							"description": "last day to be included in range in format of 'MM-dd-yyyy'",
+							"disabled": true
+						},
+						{
+							"key": "start",
+							"value": "'10-10-2020'",
+							"description": "first day to be included in range in format of 'MM-dd-yyyy'"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "Delete amenity booking",
 			"request": {
 				"method": "DELETE",

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -42,6 +42,9 @@ dependencies {
   // Spring JPA
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+  // Generator for static metamodels to support JPA2.x Criteria Queries
+  annotationProcessor 'org.hibernate:hibernate-jpamodelgen'
+
   // H2
   runtimeOnly 'com.h2database:h2'
 
@@ -115,7 +118,14 @@ jacocoTestReport {
   // https://github.com/mapstruct/mapstruct/issues/1528
   afterEvaluate {
     classDirectories.setFrom(files(classDirectories.files.collect {
-      fileTree(dir: it, exclude: ['**/mapper/**', '**/mapper'])
+      fileTree(dir: it, exclude: [
+              // Exclude generated static metamodel classes
+              '**/domain/*_.class',
+
+              // Exclude mapstruct-generated classes
+              '**/mapper/**',
+              '**/mapper'
+      ])
     }))
   }
 }

--- a/service/src/main/java/com/myhome/controllers/mapper/AmenityApiMapper.java
+++ b/service/src/main/java/com/myhome/controllers/mapper/AmenityApiMapper.java
@@ -18,10 +18,14 @@ package com.myhome.controllers.mapper;
 
 import com.myhome.controllers.dto.AmenityDto;
 import com.myhome.controllers.request.UpdateAmenityRequest;
+import com.myhome.controllers.response.amenity.GetAmenityBookingDetailsResponse;
 import com.myhome.controllers.response.amenity.GetAmenityDetailsResponse;
 import com.myhome.domain.Amenity;
+import com.myhome.domain.AmenityBookingItem;
 import java.util.Set;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
 
 @Mapper
 public interface AmenityApiMapper {
@@ -35,4 +39,16 @@ public interface AmenityApiMapper {
   AmenityDto amenityToAmenityDto(Amenity amenity);
 
   AmenityDto updateAmenityRequestToAmenityDto(UpdateAmenityRequest request);
+
+  @Mappings({
+      @Mapping(target = "amenityId", source = "amenity.amenityId"),
+      @Mapping(target = "amenityBookingId", source = "amenityBookingItemId"),
+      @Mapping(target = "startDate", source = "bookingStartDate"),
+      @Mapping(target = "endDate", source = "bookingEndDate"),
+      @Mapping(target = "bookingUserId", source = "bookingUser.userId")
+  })
+  GetAmenityBookingDetailsResponse amenityBookingToAmenityBookingsDetailsResponse(AmenityBookingItem amenityBooking);
+
+  Set<GetAmenityBookingDetailsResponse> amenityBookingsSetToAmenityBookingDetailsResponseSet(
+      Set<AmenityBookingItem> amenityBookings);
 }

--- a/service/src/main/java/com/myhome/controllers/response/amenity/GetAmenityBookingDetailsResponse.java
+++ b/service/src/main/java/com/myhome/controllers/response/amenity/GetAmenityBookingDetailsResponse.java
@@ -1,0 +1,19 @@
+package com.myhome.controllers.response.amenity;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Data
+public class GetAmenityBookingDetailsResponse {
+  private String amenityId;
+  private String amenityBookingId;
+  private LocalDateTime startDate;
+  private LocalDateTime endDate;
+  private String bookingUserId;
+}

--- a/service/src/main/java/com/myhome/repositories/AmenityBookingItemRepository.java
+++ b/service/src/main/java/com/myhome/repositories/AmenityBookingItemRepository.java
@@ -1,14 +1,11 @@
 package com.myhome.repositories;
 
-import com.myhome.domain.Amenity;
 import com.myhome.domain.AmenityBookingItem;
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface AmenityBookingItemRepository extends JpaRepository<AmenityBookingItem, String> {
-    Optional<AmenityBookingItem> findByAmenityBookingItemId(String amenityBookingItemId);
+public interface AmenityBookingItemRepository extends JpaRepository<AmenityBookingItem, String>,
+    JpaSpecificationExecutor<AmenityBookingItem> {
+  Optional<AmenityBookingItem> findByAmenityBookingItemId(String amenityBookingItemId);
 }

--- a/service/src/main/java/com/myhome/repositories/specifications/AmenityBookingItemSpecifications.java
+++ b/service/src/main/java/com/myhome/repositories/specifications/AmenityBookingItemSpecifications.java
@@ -1,0 +1,35 @@
+package com.myhome.repositories.specifications;
+
+import com.myhome.domain.AmenityBookingItem;
+import com.myhome.domain.AmenityBookingItem_;
+import com.myhome.domain.Amenity_;
+import java.time.LocalDateTime;
+import javax.persistence.criteria.Path;
+import org.springframework.data.jpa.domain.Specification;
+
+public class AmenityBookingItemSpecifications {
+
+  public static Specification<AmenityBookingItem> amenityIdEquals(String amenityId) {
+    return (root, query, criteriaBuilder) ->
+        criteriaBuilder.equal(
+            root.get(AmenityBookingItem_.AMENITY).get(Amenity_.AMENITY_ID),
+            amenityId);
+  }
+
+  public static Specification<AmenityBookingItem> startDateAfter(LocalDateTime startDate) {
+    return (root, query, criteriaBuilder) ->
+        criteriaBuilder.greaterThanOrEqualTo(root.get(AmenityBookingItem_.BOOKING_START_DATE),
+            startDate);
+  }
+
+  public static Specification<AmenityBookingItem> endDateNullOrBefore(LocalDateTime endDate) {
+    return (root, query, criteriaBuilder) -> {
+      Path<LocalDateTime> endDatePath = root.get(AmenityBookingItem_.BOOKING_END_DATE);
+
+      return criteriaBuilder.or(
+          criteriaBuilder.isNull(endDatePath),
+          criteriaBuilder.lessThanOrEqualTo(endDatePath, endDate)
+      );
+    };
+  }
+}

--- a/service/src/main/java/com/myhome/services/AmenityService.java
+++ b/service/src/main/java/com/myhome/services/AmenityService.java
@@ -18,9 +18,12 @@ package com.myhome.services;
 
 import com.myhome.controllers.dto.AmenityDto;
 import com.myhome.domain.Amenity;
+import com.myhome.domain.AmenityBookingItem;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.springframework.data.domain.Pageable;
 
 public interface AmenityService {
 
@@ -33,6 +36,9 @@ public interface AmenityService {
   Set<Amenity> listAllAmenities(String communityId);
 
   boolean updateAmenity(AmenityDto updatedAmenityDto);
+
+  Optional<Set<AmenityBookingItem>> listAmenityBookings(String amenityId, LocalDateTime startDate,
+      LocalDateTime endDate, Pageable pageable);
 
   boolean deleteBooking(String bookingId);
 }

--- a/service/src/test/java/helpers/TestUtils.java
+++ b/service/src/test/java/helpers/TestUtils.java
@@ -1,24 +1,25 @@
 package helpers;
 
 import com.myhome.domain.Amenity;
+import com.myhome.domain.AmenityBookingItem;
 import com.myhome.domain.Community;
 import com.myhome.domain.CommunityHouse;
 import com.myhome.domain.HouseMember;
 import com.myhome.domain.User;
-
-import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.imageio.ImageIO;
 
-import static helpers.TestUtils.General.generateUniqueId;
 import static helpers.TestUtils.CommunityHouseHelpers.getTestHouses;
+import static helpers.TestUtils.General.generateUniqueId;
 import static helpers.TestUtils.UserHelpers.getTestUsers;
 
 public class TestUtils {
@@ -141,6 +142,20 @@ public class TestUtils {
               .withName("default-amenity-name")
               .withDescription("default-amenity-description")
           )
+          .limit(count)
+          .collect(Collectors.toSet());
+    }
+
+    public static Set<AmenityBookingItem> getTestAmenityBookingItems(int count) {
+      Amenity amenity = getTestAmenity(generateUniqueId(), "default-amenity-description");
+
+      return Stream
+          .generate(() -> new AmenityBookingItem()
+              .withAmenity(amenity)
+              .withAmenityBookingItemId(generateUniqueId())
+              .withBookingStartDate(LocalDateTime.MIN)
+              .withBookingEndDate(LocalDateTime.MAX)
+              .withBookingUser(UserHelpers.getTestUsers(1).iterator().next()))
           .limit(count)
           .collect(Collectors.toSet());
     }


### PR DESCRIPTION
## 🚀 Description

This adds the controller method and all required plumbing.

For querying the database, I used JPA 2.0 Criteria Queries wrapped in Spring JPA's Specification framework. These style queries can perform extremely fast, while still allowing high levels of dynamism for instances here where filters are optional. In addition, the criteria queries are checked for correctness at compile-time, so there's no change that a bad HQL (or SQL) string, or a bad Spring Data method name can cause a failure at run-time.

Note that to achieve compile-time safety of the queries, I added an annotation processor to generate the required static metamodel classes. Criteria queries can still be used without the static metamodel classes, but then you won't get the compile-time query safety.

Also note that this pull request follows the desired HTTP query parameter format for `start` and `end` parameters specified in #114. The other pull request on this issue will not properly handle any date ranges because it hasn't been fully configured for it.

## 📄 Motivation and Context

This resolves #114 

## 🧪 How Has This Been Tested?

Unit tests and manual postman runs.

## 📦 Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist

- [x] My code follows the code style of this project(Do your best to follow code styles. If none apply just skip this).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
